### PR TITLE
Add interactive CLI and CAdd interactive CLI mode and Chinese READMEhinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PDF to Markdown Converter (pdfmd)
 
+[English](README.md) | [简体中文](README.zh-CN.md)
+
 **A refined, privacy-first desktop and CLI tool that converts PDFs — including scanned documents — into clean, structured Markdown. Built for researchers, professionals, and creators who demand accuracy, speed, and absolute data privacy.**
 
 **Fast. Local. Intelligent. Fully offline.**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,369 @@
+# PDF 转 Markdown 转换器（pdfmd）
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+**一个注重隐私、支持桌面界面与命令行的 PDF 转 Markdown 工具。它可以将普通 PDF 和扫描版 PDF 转换为结构清晰、便于后续编辑的 Markdown 文档。**
+
+**快速、本地、智能、完全离线。**
+
+![Python Version](https://img.shields.io/badge/python-3.8%2B-blue)
+![License](https://img.shields.io/badge/license-MIT-green)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
+![Version](https://img.shields.io/badge/version-1.6.0-purple)
+
+---
+
+## 目录
+
+- [项目特点](#项目特点)
+- [核心功能](#核心功能)
+- [安装](#安装)
+- [OCR 环境配置](#ocr-环境配置)
+- [使用方式](#使用方式)
+- [命令行示例](#命令行示例)
+- [Python API](#python-api)
+- [输出效果说明](#输出效果说明)
+- [常见问题](#常见问题)
+- [参与贡献](#参与贡献)
+- [许可证](#许可证)
+
+---
+
+## 项目特点
+
+很多 PDF 转换工具会把文件上传到远程服务器处理，而 `pdfmd` 的设计目标正好相反：
+
+- **完全本地处理**：文档不会离开你的电脑
+- **无遥测、无跟踪**：不上传、不采集使用数据
+- **支持敏感文档场景**：适合研究、法律、医疗、企业内部文档
+- **同时提供 GUI 和 CLI**：既适合普通用户，也适合自动化处理
+
+如果你的首要要求是“可离线、可本地、可控”，这个项目就是围绕这个目标构建的。
+
+---
+
+## 核心功能
+
+### 1. PDF 转 Markdown
+
+- 自动还原段落
+- 保留标题层级
+- 识别常见列表
+- 处理换行断词
+- 自动链接 URL
+- 支持粗体、斜体等基础格式
+
+### 2. 表格识别
+
+- 检测列对齐文本表格
+- 识别边框风格表格
+- 将表格输出为 Markdown pipe table
+- 尽量降低正文误判为表格的概率
+
+### 3. 数学公式支持
+
+- 识别 Unicode 数学符号
+- 将常见数学表达转换为 LaTeX 风格
+- 尽量保留已有的 `$...$` 与 `$$...$$`
+- 避免公式内容被普通 Markdown 转义破坏
+
+### 4. 扫描件 OCR
+
+- 支持 `tesseract`
+- 支持 `ocrmypdf`
+- 支持自动判断页面是否需要 OCR
+- 支持多语言 OCR
+- 支持扫描 PDF 与普通 PDF 混合场景
+
+### 5. 图形界面与交互式 CLI
+
+- 提供桌面 GUI
+- 提供传统命令行参数模式
+- 提供引导式交互 CLI
+- 支持中文交互界面
+
+---
+
+## 安装
+
+### 方式一：使用 pip
+
+```bash
+pip install -e .
+```
+
+如果需要 OCR：
+
+```bash
+pip install pytesseract pillow
+```
+
+如果还需要 `ocrmypdf`：
+
+```bash
+pip install ocrmypdf
+```
+
+### 方式二：使用 uv
+
+在项目目录下：
+
+```powershell
+uv venv
+.venv\Scripts\Activate.ps1
+uv pip install -e .
+uv pip install pytesseract pillow
+```
+
+如果你需要 `ocrmypdf`：
+
+```powershell
+uv pip install ocrmypdf
+```
+
+---
+
+## OCR 环境配置
+
+Python 包安装完成后，还需要准备系统级 OCR 工具。
+
+### Tesseract
+
+`tesseract` 模式必须安装 Tesseract 可执行程序。
+
+Windows 推荐：
+
+- [UB Mannheim Tesseract](https://github.com/UB-Mannheim/tesseract/wiki)
+
+安装完成后，请确认它已加入 `PATH`，然后执行：
+
+```powershell
+tesseract --version
+tesseract --list-langs
+```
+
+如果你要做中英混合识别，至少需要准备：
+
+- `eng.traineddata`
+- `chi_sim.traineddata`
+
+### OCRmyPDF
+
+如果你要使用 `ocrmypdf` 模式，除了 Python 包之外，还要确保 `ocrmypdf` 命令可用：
+
+```powershell
+ocrmypdf --version
+```
+
+建议先把 `tesseract` 模式跑通，再尝试 `ocrmypdf`。
+
+---
+
+## 使用方式
+
+### 图形界面
+
+启动 GUI：
+
+```bash
+python -m pdfmd.app_gui
+```
+
+GUI 适合：
+
+- 拖选文件
+- 调整 OCR 选项
+- 查看进度和日志
+- 批量转换
+
+### 传统 CLI
+
+最简单的转换：
+
+```bash
+python -m pdfmd input.pdf
+```
+
+指定输出文件：
+
+```bash
+python -m pdfmd input.pdf -o output.md
+```
+
+开启自动 OCR：
+
+```bash
+python -m pdfmd input.pdf --ocr auto
+```
+
+### 交互式 CLI
+
+如果你希望一步一步选择参数：
+
+```bash
+python -m pdfmd --interactive
+```
+
+中文界面：
+
+```bash
+python -m pdfmd --interactive --ui-lang zh
+```
+
+如果在交互终端中直接运行：
+
+```bash
+python -m pdfmd
+```
+
+也会自动进入交互式模式。
+
+---
+
+## 命令行示例
+
+### 1. 普通 PDF 转 Markdown
+
+```bash
+python -m pdfmd report.pdf
+```
+
+### 2. 输出到指定文件
+
+```bash
+python -m pdfmd report.pdf -o notes.md
+```
+
+### 3. 自动 OCR
+
+```bash
+python -m pdfmd scan.pdf --ocr auto
+```
+
+### 4. 强制使用 Tesseract
+
+```bash
+python -m pdfmd scan.pdf --ocr tesseract --lang chi_sim+eng
+```
+
+### 5. 只预览前几页
+
+```bash
+python -m pdfmd long.pdf --preview-only --stats
+```
+
+### 6. 批量转换
+
+```bash
+python -m pdfmd *.pdf -o out_md
+```
+
+### 7. 导出图片资源
+
+```bash
+python -m pdfmd input.pdf --export-images
+```
+
+---
+
+## Python API
+
+你也可以直接在 Python 中调用：
+
+```python
+from pdfmd import Options, pdf_to_markdown
+
+opts = Options(
+    ocr_mode="auto",
+    ocr_lang="chi_sim+eng",
+    preview_only=False,
+    insert_page_breaks=False,
+    export_images=False,
+)
+
+pdf_to_markdown("input.pdf", "output.md", opts)
+```
+
+---
+
+## 输出效果说明
+
+转换后的 Markdown 通常会包含这些能力：
+
+- 自动拆出标题
+- 尽量合并被换行打断的段落
+- 尽量把表格转成 Markdown 表格
+- 尽量保留数学表达
+- 可选插入分页标记 `---`
+- 可选导出图片到 `_assets` 目录
+
+对于扫描版 PDF，最终质量会明显受这些因素影响：
+
+- 原始扫描清晰度
+- 页面倾斜情况
+- 字体与布局复杂度
+- OCR 语言选择是否准确
+
+---
+
+## 常见问题
+
+### 1. `python -m pdfmd` 无法启动
+
+请确认你安装的是当前项目代码，并且模块入口可用：
+
+```bash
+python -m pdfmd --version
+```
+
+### 2. Tesseract 找不到语言包
+
+如果看到类似错误：
+
+```text
+Tesseract couldn't load any languages
+```
+
+通常说明：
+
+- `tessdata` 目录里没有对应语言文件
+- 或 `TESSDATA_PREFIX` 配置不正确
+
+### 3. `ocrmypdf` 模式无法运行
+
+请先验证：
+
+```bash
+ocrmypdf --version
+```
+
+并确认系统里已经装好依赖工具。
+
+### 4. 扫描件识别结果有较多空格或错字
+
+这是 OCR 场景中常见的问题。可以优先尝试：
+
+- 提高扫描清晰度
+- 选择更合适的 OCR 语言
+- 先试 `tesseract`
+- 再对比 `ocrmypdf`
+
+---
+
+## 参与贡献
+
+欢迎提交 issue、改进建议或 Pull Request。
+
+适合贡献的方向包括：
+
+- OCR 准确率提升
+- 表格识别增强
+- 数学公式处理增强
+- CLI / GUI 体验优化
+- 文档与测试补充
+
+---
+
+## 许可证
+
+本项目采用 [MIT License](LICENSE)。

--- a/pdfmd/__main__.py
+++ b/pdfmd/__main__.py
@@ -1,0 +1,9 @@
+"""Module entry point for ``python -m pdfmd``."""
+
+from __future__ import annotations
+
+from . import main
+
+
+if __name__ == "__main__":
+    main()

--- a/pdfmd/cli.py
+++ b/pdfmd/cli.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Callable, Iterable, List, Optional, Sequence
 
 from .models import Options
+from .ocr_lang import normalize_ocr_lang
 from .pipeline import pdf_to_markdown
 
 
@@ -152,9 +153,9 @@ Security notes:
         default="eng",
         help=(
             "Tesseract language code(s) for OCR (default: eng).\n"
-            "Use a Tesseract language code, e.g. 'deu' for German,\n"
-            "'fra' for French, 'jpn' for Japanese.\n"
-            "Combine with '+' for multiple: 'eng+fra'.\n"
+            "Use a Tesseract language code or a common alias, e.g. 'deu',\n"
+            "'German', '中文', 'chi_sim', 'jpn'.\n"
+            "Combine with '+' for multiple: 'eng+fra' or '中文+english'.\n"
             "Only used when --ocr is not 'off'."
         ),
     )
@@ -219,6 +220,19 @@ Security notes:
         help="Print version and exit.",
     )
 
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Launch the guided interactive CLI.",
+    )
+
+    parser.add_argument(
+        "--ui-lang",
+        choices=["auto", "en", "zh"],
+        default="auto",
+        help="Interactive CLI language (default: auto).",
+    )
+
     return parser
 
 
@@ -232,7 +246,7 @@ def _make_options(args: argparse.Namespace) -> Options:
 
     # Extraction / OCR
     opts.ocr_mode = args.ocr
-    opts.ocr_lang = args.lang or "eng"
+    opts.ocr_lang = normalize_ocr_lang(args.lang or "eng")
     opts.preview_only = bool(args.preview_only)
 
     # Rendering / output
@@ -506,6 +520,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.version:
         print(f"pdfmd {_VERSION}")
         return 0
+
+    if args.interactive or (not args.inputs and sys.stdin.isatty() and sys.stdout.isatty()):
+        from .interactive_cli import run_interactive_cli
+
+        return run_interactive_cli(ui_lang=args.ui_lang)
 
     # NOW check if inputs were provided
     if not args.inputs:

--- a/pdfmd/interactive_cli.py
+++ b/pdfmd/interactive_cli.py
@@ -1,0 +1,543 @@
+"""Guided interactive CLI for pdfmd.
+
+This module provides a lightweight terminal experience for users who prefer a
+step-by-step workflow over passing command-line flags manually.
+"""
+
+from __future__ import annotations
+
+import getpass
+import locale
+import shutil
+import sys
+from dataclasses import dataclass
+from urllib.parse import unquote, urlparse
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+from .cli import (
+    _Colors,
+    _compute_stats,
+    _make_colors,
+    _print_stats,
+)
+from .extract import _HAS_PIL, _HAS_TESS, _tesseract_available
+from .models import Options
+from .pipeline import pdf_to_markdown
+
+
+_ABORT = "__PDFMD_ABORT__"
+
+
+@dataclass(frozen=True)
+class _OcrLanguageChoice:
+    value: str
+    label_en: str
+    label_zh: str
+
+
+OCR_LANGUAGE_CHOICES: tuple[_OcrLanguageChoice, ...] = (
+    _OcrLanguageChoice("eng", "English (eng)", "英文 (eng)"),
+    _OcrLanguageChoice("chi_sim", "Simplified Chinese (chi_sim)", "简体中文 (chi_sim)"),
+    _OcrLanguageChoice("chi_sim+eng", "Chinese + English (chi_sim+eng)", "中英混合 (chi_sim+eng)"),
+    _OcrLanguageChoice("chi_tra", "Traditional Chinese (chi_tra)", "繁体中文 (chi_tra)"),
+    _OcrLanguageChoice("chi_tra+eng", "Traditional Chinese + English (chi_tra+eng)", "繁中混合 (chi_tra+eng)"),
+    _OcrLanguageChoice("jpn", "Japanese (jpn)", "日文 (jpn)"),
+    _OcrLanguageChoice("jpn+eng", "Japanese + English (jpn+eng)", "日英混合 (jpn+eng)"),
+    _OcrLanguageChoice("kor", "Korean (kor)", "韩文 (kor)"),
+    _OcrLanguageChoice("kor+eng", "Korean + English (kor+eng)", "韩英混合 (kor+eng)"),
+)
+
+MESSAGES = {
+    "en": {
+        "input_closed": "Input stream closed. Exiting interactive mode.",
+        "cancelled_exit": "Cancelled. Exiting interactive mode.",
+        "answer_yes_no": "Please answer with 'y' or 'n'.",
+        "choose_listed": "Please choose a listed number or value.",
+        "enter_pdf_path": "Please enter a PDF path.",
+        "help_path_intro": "Paste a local PDF path. Quoted Windows paths and drag-and-drop paths are supported.",
+        "examples": "Examples:",
+        "help_exit": "Type 'q' to exit interactive mode.",
+        "file_not_found": "File not found: {path}",
+        "folder_not_pdf": "That is a folder, not a PDF file: {path}",
+        "not_a_file": "Not a file: {path}",
+        "choose_pdf": "Please choose a .pdf file, not: {name}",
+        "output_not_dir": "Output must be a Markdown file path, not a directory.",
+        "output_should_md": "Output should end with .md",
+        "ocr_mode": "OCR mode:",
+        "ocr_lang": "OCR language:",
+        "export_images": "Export images to an _assets folder?",
+        "page_breaks": "Insert page break markers?",
+        "preview_only": "Preview only the first few pages?",
+        "show_stats": "Show basic Markdown stats after conversion?",
+        "default_marker": " (default)",
+        "choice_prompt": "Choose 1-{count} [{default_index}]: ",
+        "ocr_tesseract_pkg_missing": "Tesseract OCR needs both pytesseract and Pillow. Install them with: pip install pytesseract pillow",
+        "ocr_tesseract_bin_missing": "Tesseract binary was not found on PATH. Install Tesseract and restart the terminal.",
+        "ocr_ocrmypdf_missing": "OCRmyPDF was not found on PATH. Install it with: pip install ocrmypdf",
+        "ocr_preflight_blocked": "OCR preflight check failed. Please fix the issue above and try again.",
+        "password_prompt": "PDF is password protected. Enter password (input will be hidden): ",
+        "password_cancelled": "Password entry cancelled.",
+        "password_missing": "No password provided; conversion cancelled.",
+        "error": "Error:",
+        "saved": "Saved:",
+        "interactive_mode": "pdfmd interactive mode",
+        "guided_intro": "Guided PDF to Markdown conversion. Type 'q' at the PDF prompt to exit.",
+        "bye": "Bye.",
+        "cancelled_run": "Cancelled current run.",
+        "ready": "Ready to convert:",
+        "label_input": "Input",
+        "label_output": "Output",
+        "label_ocr": "OCR",
+        "label_lang": "Lang",
+        "label_images": "Images",
+        "label_breaks": "Breaks",
+        "label_preview": "Preview",
+        "yes": "yes",
+        "no": "no",
+        "start_now": "Start conversion now?",
+        "conversion_skipped": "Conversion skipped.",
+        "convert_another": "Convert another PDF?",
+        "quit_prompt": "Input PDF path (or 'q' to quit)",
+        "output_prompt": "Output Markdown path",
+    },
+    "zh": {
+        "input_closed": "输入流已结束，正在退出交互模式。",
+        "cancelled_exit": "已取消，正在退出交互模式。",
+        "answer_yes_no": "请输入 'y' 或 'n'。",
+        "choose_listed": "请输入列表里的编号或选项值。",
+        "enter_pdf_path": "请输入 PDF 路径。",
+        "help_path_intro": "请粘贴本地 PDF 路径。支持带引号的 Windows 路径，也支持拖拽到终端后的路径。",
+        "examples": "示例：",
+        "help_exit": "输入 'q' 可退出交互模式。",
+        "file_not_found": "文件不存在：{path}",
+        "folder_not_pdf": "这是一个文件夹，不是 PDF 文件：{path}",
+        "not_a_file": "这不是一个文件：{path}",
+        "choose_pdf": "请选择 .pdf 文件，而不是：{name}",
+        "output_not_dir": "输出路径必须是 Markdown 文件路径，不能是目录。",
+        "output_should_md": "输出文件应以 .md 结尾。",
+        "ocr_mode": "OCR 模式：",
+        "ocr_lang": "OCR 语言：",
+        "export_images": "是否把图片导出到 _assets 文件夹？",
+        "page_breaks": "是否插入分页标记？",
+        "preview_only": "是否只预览前几页？",
+        "show_stats": "转换完成后是否显示 Markdown 统计信息？",
+        "default_marker": "（默认）",
+        "choice_prompt": "请选择 1-{count} [{default_index}]：",
+        "ocr_tesseract_pkg_missing": "Tesseract OCR 需要同时安装 pytesseract 和 Pillow。可执行：pip install pytesseract pillow",
+        "ocr_tesseract_bin_missing": "没有在 PATH 中找到 Tesseract 可执行文件。请先安装 Tesseract，然后重新打开终端。",
+        "ocr_ocrmypdf_missing": "没有在 PATH 中找到 OCRmyPDF。可执行：pip install ocrmypdf",
+        "ocr_preflight_blocked": "OCR 预检查未通过。请先修复上面的依赖问题，再重新尝试。",
+        "password_prompt": "PDF 已加密。请输入密码（输入内容不会显示）：",
+        "password_cancelled": "已取消密码输入。",
+        "password_missing": "未提供密码，本次转换已取消。",
+        "error": "错误：",
+        "saved": "已保存：",
+        "interactive_mode": "pdfmd 交互模式",
+        "guided_intro": "这是一个引导式 PDF 转 Markdown 流程。你可以在 PDF 路径提示处输入 'q' 退出。",
+        "bye": "再见。",
+        "cancelled_run": "已取消当前这轮转换。",
+        "ready": "准备开始转换：",
+        "label_input": "输入",
+        "label_output": "输出",
+        "label_ocr": "OCR",
+        "label_lang": "语言",
+        "label_images": "图片导出",
+        "label_breaks": "分页",
+        "label_preview": "预览",
+        "yes": "是",
+        "no": "否",
+        "start_now": "现在开始转换吗？",
+        "conversion_skipped": "已跳过本次转换。",
+        "convert_another": "要继续转换另一个 PDF 吗？",
+        "quit_prompt": "输入 PDF 路径（或输入 'q' 退出）",
+        "output_prompt": "输出 Markdown 路径",
+    },
+}
+
+
+def _write(line: str = "") -> None:
+    print(line)
+
+
+def _resolve_ui_lang(ui_lang: str) -> str:
+    if ui_lang in {"en", "zh"}:
+        return ui_lang
+    lang = ""
+    try:
+        lang = locale.getdefaultlocale()[0] or ""
+    except Exception:
+        lang = ""
+    lang = lang.lower()
+    if "zh" in lang:
+        return "zh"
+    return "en"
+
+
+def _t(lang: str, key: str, **kwargs: object) -> str:
+    template = MESSAGES.get(lang, MESSAGES["en"]).get(key, MESSAGES["en"][key])
+    return template.format(**kwargs)
+
+
+def _safe_input(prompt: str, lang: str) -> Optional[str]:
+    try:
+        return input(prompt)
+    except EOFError:
+        _write()
+        _write(_t(lang, "input_closed"))
+        return None
+    except KeyboardInterrupt:
+        _write()
+        _write(_t(lang, "cancelled_exit"))
+        return None
+
+
+def _prompt_text(prompt: str, lang: str, default: Optional[str] = None) -> str:
+    suffix = f" [{default}]" if default else ""
+    raw_in = _safe_input(f"{prompt}{suffix}: ", lang)
+    if raw_in is None:
+        return _ABORT
+    raw = raw_in.strip()
+    if raw:
+        return raw
+    return default or ""
+
+
+def _normalize_path_input(raw: str) -> str:
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {'"', "'"}:
+        raw = raw[1:-1].strip()
+    if raw.lower().startswith("file:///"):
+        parsed = urlparse(raw)
+        raw = unquote(parsed.path or "")
+        if raw.startswith("/") and len(raw) > 2 and raw[2] == ":":
+            raw = raw[1:]
+        raw = raw.replace("/", "\\")
+    return raw
+
+
+def _prompt_yes_no(prompt: str, lang: str, default: bool = False) -> bool:
+    default_label = "Y/n" if default else "y/N"
+    while True:
+        raw_in = _safe_input(f"{prompt} [{default_label}]: ", lang)
+        if raw_in is None:
+            return False
+        raw = raw_in.strip().lower()
+        if not raw:
+            return default
+        if raw in {"y", "yes", "是"}:
+            return True
+        if raw in {"n", "no", "否"}:
+            return False
+        _write(_t(lang, "answer_yes_no"))
+
+
+def _prompt_choice(prompt: str, choices: list[str], lang: str, default: str) -> str:
+    default_pos = choices.index(default)
+    default_index = str(default_pos + 1)
+
+    _write(prompt)
+    for pos, choice in enumerate(choices, start=1):
+        marker = _t(lang, "default_marker") if choice == default else ""
+        _write(f"  {pos}. {choice}{marker}")
+
+    while True:
+        raw_in = _safe_input(
+            _t(lang, "choice_prompt", count=len(choices), default_index=default_index),
+            lang,
+        )
+        if raw_in is None:
+            return default
+        raw = raw_in.strip().lower()
+        if not raw:
+            return default
+        if raw.isdigit():
+            idx = int(raw) - 1
+            if 0 <= idx < len(choices):
+                return choices[idx]
+        if raw in choices:
+            return raw
+        _write(_t(lang, "choose_listed"))
+
+
+def _prompt_input_pdf(lang: str) -> Optional[Path]:
+    while True:
+        raw = _prompt_text(_t(lang, "quit_prompt"), lang)
+        if raw == _ABORT:
+            return None
+        if not raw:
+            _write(_t(lang, "enter_pdf_path"))
+            continue
+        if raw.lower() in {"h", "help", "?"}:
+            _write(_t(lang, "help_path_intro"))
+            _write(_t(lang, "examples"))
+            _write(r"  L:\Docs\report.pdf")
+            _write(r'  "L:\Docs\report.pdf"')
+            _write(r"  file:///L:/Docs/report.pdf")
+            _write(_t(lang, "help_exit"))
+            continue
+        if raw.lower() in {"q", "quit", "exit"}:
+            return None
+
+        path = Path(_normalize_path_input(raw)).expanduser()
+        if not path.exists():
+            _write(_t(lang, "file_not_found", path=path))
+            continue
+        if not path.is_file():
+            if path.is_dir():
+                _write(_t(lang, "folder_not_pdf", path=path))
+            else:
+                _write(_t(lang, "not_a_file", path=path))
+            continue
+        if path.suffix.lower() != ".pdf":
+            _write(_t(lang, "choose_pdf", name=path.name))
+            continue
+        return path
+
+
+def _prompt_output_md(input_pdf: Path, lang: str) -> Path:
+    default = str(input_pdf.with_suffix(".md"))
+    while True:
+        raw = _prompt_text(_t(lang, "output_prompt"), lang, default=default)
+        if raw == _ABORT:
+            raise KeyboardInterrupt
+        raw = _normalize_path_input(raw)
+        outp = Path(raw).expanduser()
+        if outp.exists() and outp.is_dir():
+            _write(_t(lang, "output_not_dir"))
+            continue
+        if outp.suffix.lower() != ".md":
+            _write(_t(lang, "output_should_md"))
+            continue
+        return outp
+
+
+def _ocr_language_labels(lang: str) -> list[str]:
+    if lang == "zh":
+        return [choice.label_zh for choice in OCR_LANGUAGE_CHOICES]
+    return [choice.label_en for choice in OCR_LANGUAGE_CHOICES]
+
+
+def _prompt_ocr_language(lang: str) -> str:
+    labels = _ocr_language_labels(lang)
+    selected_label = _prompt_choice(
+        _t(lang, "ocr_lang"),
+        labels,
+        lang,
+        default=labels[0],
+    )
+    selected_index = labels.index(selected_label)
+    return OCR_LANGUAGE_CHOICES[selected_index].value
+
+
+def _format_bool(lang: str, value: bool) -> str:
+    return _t(lang, "yes") if value else _t(lang, "no")
+
+
+def _build_conversion_summary(input_pdf: Path, output_md: Path, options: Options, lang: str) -> list[str]:
+    lines = [
+        _t(lang, "ready"),
+        f"  {_t(lang, 'label_input')}:  {input_pdf}",
+        f"  {_t(lang, 'label_output')}: {output_md}",
+        f"  {_t(lang, 'label_ocr')}:    {options.ocr_mode}",
+    ]
+    if options.ocr_mode != "off":
+        lines.append(f"  {_t(lang, 'label_lang')}:   {options.ocr_lang}")
+    lines.extend(
+        [
+            f"  {_t(lang, 'label_images')}: {_format_bool(lang, options.export_images)}",
+            f"  {_t(lang, 'label_breaks')}: {_format_bool(lang, options.insert_page_breaks)}",
+            f"  {_t(lang, 'label_preview')}: {_format_bool(lang, options.preview_only)}",
+        ]
+    )
+    return lines
+
+
+def _build_options(lang: str) -> tuple[Options, bool]:
+    ocr_mode = _prompt_choice(
+        _t(lang, "ocr_mode"),
+        ["off", "auto", "tesseract", "ocrmypdf"],
+        lang,
+        default="off",
+    )
+
+    ocr_lang = "eng"
+    if ocr_mode != "off":
+        ocr_lang = _prompt_ocr_language(lang)
+
+    export_images = _prompt_yes_no(_t(lang, "export_images"), lang, default=False)
+    page_breaks = _prompt_yes_no(_t(lang, "page_breaks"), lang, default=False)
+    preview_only = _prompt_yes_no(_t(lang, "preview_only"), lang, default=False)
+    stats = _prompt_yes_no(_t(lang, "show_stats"), lang, default=True)
+
+    return (
+        Options(
+            ocr_mode=ocr_mode,
+            ocr_lang=ocr_lang,
+            preview_only=preview_only,
+            insert_page_breaks=page_breaks,
+            export_images=export_images,
+        ),
+        stats,
+    )
+
+
+def _check_ocr_dependencies(options: Options, lang: str) -> bool:
+    mode = (options.ocr_mode or "off").lower()
+    if mode == "off" or mode == "auto":
+        return True
+
+    if mode == "tesseract":
+        ok = True
+        if not (_HAS_TESS and _HAS_PIL):
+            _write(_t(lang, "ocr_tesseract_pkg_missing"))
+            ok = False
+        if not _tesseract_available():
+            _write(_t(lang, "ocr_tesseract_bin_missing"))
+            ok = False
+        if not ok:
+            _write(_t(lang, "ocr_preflight_blocked"))
+        return ok
+
+    if mode == "ocrmypdf":
+        ok = True
+        if not _tesseract_available():
+            _write(_t(lang, "ocr_tesseract_bin_missing"))
+            ok = False
+        if shutil.which("ocrmypdf") is None:
+            _write(_t(lang, "ocr_ocrmypdf_missing"))
+            ok = False
+        if not ok:
+            _write(_t(lang, "ocr_preflight_blocked"))
+        return ok
+
+    return True
+
+
+def _make_progress_cb(file_label: str, colors: _Colors) -> Callable[[int, int], None]:
+    def progress_cb(done: int, total: int) -> None:
+        if total == 100 and 0 <= done <= 100:
+            pct = int(done)
+        else:
+            pct = int(done * 100 / total) if total > 0 else 0
+        pct = max(0, min(100, pct))
+
+        bar_width = 24
+        filled = int(bar_width * pct / 100)
+        bar = "#" * filled + "." * (bar_width - filled)
+        sys.stderr.write(
+            f"\r{colors.info}[{bar}] {pct:3d}%  {file_label}{colors.reset}"
+        )
+        sys.stderr.flush()
+        if pct >= 100:
+            sys.stderr.write("\n")
+            sys.stderr.flush()
+
+    return progress_cb
+
+
+def _run_conversion(
+    input_pdf: Path,
+    output_md: Path,
+    options: Options,
+    show_stats: bool,
+    colors: _Colors,
+    lang: str,
+) -> bool:
+    password: Optional[str] = None
+    progress_cb = _make_progress_cb(input_pdf.name, colors)
+
+    def log_cb(message: str) -> None:
+        _write(f"{colors.info}{message}{colors.reset}")
+
+    def run_once(pdf_password: Optional[str]) -> None:
+        pdf_to_markdown(
+            str(input_pdf),
+            str(output_md),
+            options,
+            progress_cb=progress_cb,
+            log_cb=log_cb,
+            pdf_password=pdf_password,
+        )
+
+    try:
+        run_once(password)
+    except Exception as exc:
+        lower = str(exc).lower()
+        password_keywords = [
+            "password required",
+            "password is required",
+            "incorrect pdf password",
+            "wrong password",
+            "cannot decrypt",
+            "encrypted",
+        ]
+        if any(keyword in lower for keyword in password_keywords):
+            try:
+                password = getpass.getpass(
+                    _t(lang, "password_prompt")
+                )
+            except (EOFError, KeyboardInterrupt):
+                _write()
+                _write(f"{colors.warn}{_t(lang, 'password_cancelled')}{colors.reset}")
+                return False
+            if not password:
+                _write(f"{colors.warn}{_t(lang, 'password_missing')}{colors.reset}")
+                return False
+            try:
+                run_once(password)
+            except Exception as retry_exc:
+                _write(f"{colors.err}{_t(lang, 'error')}{colors.reset} {retry_exc}")
+                return False
+        else:
+            _write(f"{colors.err}{_t(lang, 'error')}{colors.reset} {exc}")
+            return False
+    finally:
+        password = None
+
+    _write(f"{colors.ok}{_t(lang, 'saved')}{colors.reset} {output_md}")
+    if show_stats:
+        stats = _compute_stats(output_md)
+        _print_stats(output_md, stats, colors)
+    return True
+
+
+def run_interactive_cli(ui_lang: str = "auto") -> int:
+    lang = _resolve_ui_lang(ui_lang)
+    colors = _make_colors(sys.stderr.isatty())
+
+    _write()
+    _write(f"{colors.ok}{_t(lang, 'interactive_mode')}{colors.reset}")
+    _write(_t(lang, "guided_intro"))
+    _write()
+
+    while True:
+        input_pdf = _prompt_input_pdf(lang)
+        if input_pdf is None:
+            _write(_t(lang, "bye"))
+            return 0
+
+        try:
+            output_md = _prompt_output_md(input_pdf, lang)
+        except KeyboardInterrupt:
+            _write(_t(lang, "cancelled_run"))
+            _write()
+            continue
+        options, show_stats = _build_options(lang)
+
+        _write()
+        for line in _build_conversion_summary(input_pdf, output_md, options, lang):
+            _write(line)
+        _write()
+
+        if not _prompt_yes_no(_t(lang, "start_now"), lang, default=True):
+            _write(_t(lang, "conversion_skipped"))
+        else:
+            if _check_ocr_dependencies(options, lang):
+                _run_conversion(input_pdf, output_md, options, show_stats, colors, lang)
+
+        _write()
+        if not _prompt_yes_no(_t(lang, "convert_another"), lang, default=True):
+            _write(_t(lang, "bye"))
+            return 0
+        _write()

--- a/pdfmd/ocr_lang.py
+++ b/pdfmd/ocr_lang.py
@@ -1,0 +1,124 @@
+"""OCR language normalization helpers.
+
+These helpers translate friendly user input such as ``chinese`` or ``中文``
+into Tesseract language codes such as ``chi_sim``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+
+_ALIAS_GROUPS = {
+    "eng": ("eng", "en", "english", "英文", "英语"),
+    "deu": ("deu", "de", "german", "deutsch", "德语", "德文"),
+    "fra": ("fra", "fr", "french", "francais", "français", "法语", "法文"),
+    "spa": ("spa", "es", "spanish", "espanol", "español", "西班牙语"),
+    "ita": ("ita", "it", "italian", "意大利语"),
+    "por": ("por", "pt", "portuguese", "葡萄牙语"),
+    "nld": ("nld", "nl", "dutch", "荷兰语"),
+    "pol": ("pol", "pl", "polish", "波兰语"),
+    "rus": ("rus", "ru", "russian", "俄语"),
+    "chi_sim": (
+        "chi sim",
+        "chi_sim",
+        "chi-sim",
+        "zh",
+        "zh_cn",
+        "zh-cn",
+        "cn",
+        "chinese",
+        "simplifiedchinese",
+        "chinesesimplified",
+        "simplified chinese",
+        "chinese simplified",
+        "中文",
+        "汉语",
+        "汉字",
+        "简体",
+        "简体中文",
+        "简中",
+        "普通话",
+    ),
+    "chi_tra": (
+        "chi tra",
+        "chi_tra",
+        "chi-tra",
+        "zh_tw",
+        "zh-tw",
+        "zh_hant",
+        "zh-hant",
+        "traditionalchinese",
+        "chinesetraditional",
+        "traditional chinese",
+        "chinese traditional",
+        "繁体",
+        "繁體",
+        "繁体中文",
+        "繁體中文",
+        "繁中",
+    ),
+    "jpn": ("jpn", "ja", "jp", "japanese", "日语", "日文", "日本語"),
+    "kor": ("kor", "ko", "kr", "korean", "韩语", "韓語", "한국어"),
+    "ara": ("ara", "ar", "arabic", "阿拉伯语"),
+    "hin": ("hin", "hi", "hindi", "印地语"),
+    "tur": ("tur", "tr", "turkish", "土耳其语"),
+    "vie": ("vie", "vi", "vietnamese", "越南语"),
+}
+
+
+def _normalize_alias_key(value: str) -> str:
+    return re.sub(r"[\s_\-]+", "", value.strip().lower())
+
+
+_ALIASES_BY_KEY = {
+    _normalize_alias_key(alias): code
+    for code, aliases in _ALIAS_GROUPS.items()
+    for alias in aliases
+}
+
+_SPLIT_RE = re.compile(r"\s*(?:\+|,|;|/|\||、|，|\band\b|\bplus\b|和|与)\s*", re.IGNORECASE)
+
+
+def _normalize_part(part: str) -> str:
+    raw = part.strip().strip("'\"")
+    if not raw:
+        return ""
+
+    alias_key = _normalize_alias_key(raw)
+    if alias_key in _ALIASES_BY_KEY:
+        return _ALIASES_BY_KEY[alias_key]
+
+    return raw.lower()
+
+
+def normalize_ocr_lang(value: str | None, default: str = "eng") -> str:
+    """Normalize friendly OCR language input to Tesseract codes.
+
+    Examples:
+        ``"chinese"`` -> ``"chi_sim"``
+        ``"中文+english"`` -> ``"chi_sim+eng"``
+        ``"zh-cn, en"`` -> ``"chi_sim+eng"``
+    """
+    if value is None:
+        return default
+
+    raw = value.strip()
+    if not raw:
+        return default
+
+    parts = _SPLIT_RE.split(raw)
+    normalized: List[str] = []
+
+    for part in parts:
+        code = _normalize_part(part)
+        if not code:
+            continue
+        if code not in normalized:
+            normalized.append(code)
+
+    return "+".join(normalized) if normalized else default
+
+
+__all__ = ["normalize_ocr_lang"]


### PR DESCRIPTION
## Summary

This PR adds a guided interactive CLI experience for `pdfmd` and introduces a Simplified Chinese README.

## Changes

- add `python -m pdfmd` entrypoint support via `pdfmd/__main__.py`
- add guided interactive CLI flow in `pdfmd/interactive_cli.py`
- add `--interactive` flag for launching the guided CLI
- add `--ui-lang` option for interactive CLI language selection
- add OCR language normalization helper in `pdfmd/ocr_lang.py`
- update CLI entry handling in `pdfmd/cli.py`
- add `README.zh-CN.md`
- add language switch links between English and Chinese README files

## Why

The current CLI works well for users already familiar with command-line flags, but it is less friendly for users who prefer a guided workflow.

This change aims to:

- lower the barrier to entry for new CLI users
- make OCR-related choices easier to understand during interactive use
- improve accessibility for Chinese-speaking users through localized documentation

## Notes

- this PR focuses on CLI usability and documentation only
- OCR engine behavior and rendering heuristics are intentionally not included in this PR
- the Chinese README is added as a separate document rather than replacing the existing English README

## Manual testing

- verified `python -m pdfmd --version`
- verified `python -m pdfmd --interactive`
- verified interactive CLI flow in Chinese mode with `--ui-lang zh`
- verified OCR language menu selection in interactive mode
- verified README language switch links
