### PR TITLE
Fix --page-breaks and extend it's capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,8 +734,11 @@ pdfmd japanese_doc.pdf --ocr tesseract --lang jpn
 
 **🖼️ Documents with Images**
 ```bash
-# Extract images to _assets/ folder with references
+# Extract images to _assets/ folder with references (white background)
 pdfmd presentation.pdf --export-images
+
+# Keep transparent backgrounds in exported images
+pdfmd presentation.pdf --export-images transparent
 
 # OCR + images for scanned slides
 pdfmd slides.pdf --ocr auto --export-images
@@ -784,7 +787,8 @@ pdfmd document.pdf -v --no-color
 
 ```
 usage: pdfmd [-h] [-o OUTPUT] [--ocr {off,auto,tesseract,ocrmypdf}]
-             [--lang LANG] [--export-images] [--page-breaks [{visible,hidden}]]
+             [--lang LANG] [--export-images [{white,black,transparent}]]
+             [--page-breaks [{visible,hidden}]]
              [--preview-only]
              [--no-progress] [-q] [-v] [--stats] [--no-color] [--version]
              INPUT_PDF [INPUT_PDF ...]
@@ -817,8 +821,13 @@ options:
                         Combine with '+' for multiple: 'eng+fra'.
                         Only used when --ocr is not 'off'.
   
-  --export-images       Export images to _assets/ folder next to output file,
+  --export-images [MODE]
+                        Export images to _assets/ folder next to output file,
                         with Markdown image references appended to document.
+                        MODE sets the background for transparent pixels:
+                          white       — composite onto white (default)
+                          black       — composite onto black
+                          transparent — keep alpha channel intact
   
   --page-breaks [MODE]  Insert page markers between pages (default: visible).
                         visible — '---' horizontal rule between pages.
@@ -906,13 +915,13 @@ pdfmd *.pdf -o converted/
 **Image Export:**
 ```bash
 pdfmd slides.pdf --export-images
-# Creates:
-#   slides.md
-#   slides_assets/
-#     ├── img_001_01.png
-#     ├── img_001_02.png
-#     └── ...
-# Images referenced at end of slides.md
+# Creates slides_assets/ with white background for transparent pixels (default)
+
+pdfmd slides.pdf --export-images transparent
+# Keeps alpha channel intact in exported PNGs
+
+pdfmd slides.pdf --export-images black
+# Uses black background for transparent pixels
 ```
 
 #### CLI Error Handling

--- a/README.md
+++ b/README.md
@@ -784,7 +784,8 @@ pdfmd document.pdf -v --no-color
 
 ```
 usage: pdfmd [-h] [-o OUTPUT] [--ocr {off,auto,tesseract,ocrmypdf}]
-             [--lang LANG] [--export-images] [--page-breaks] [--preview-only]
+             [--lang LANG] [--export-images] [--page-breaks [{visible,hidden}]]
+             [--preview-only]
              [--no-progress] [-q] [-v] [--stats] [--no-color] [--version]
              INPUT_PDF [INPUT_PDF ...]
 
@@ -819,7 +820,10 @@ options:
   --export-images       Export images to _assets/ folder next to output file,
                         with Markdown image references appended to document.
   
-  --page-breaks         Insert '---' horizontal rule between pages in output.
+  --page-breaks [MODE]  Insert page markers between pages (default: visible).
+                        visible — '---' horizontal rule between pages.
+                        hidden  — '<!-- Page N -->' HTML comments (preserves
+                        cross-page paragraph flow; ideal for LLM ingestion).
   
   --preview-only        Only process first 3 pages (useful for quick inspection
                         of large documents or testing settings).

--- a/pdfmd/app_gui.py
+++ b/pdfmd/app_gui.py
@@ -1024,7 +1024,7 @@ class PdfMdApp(tk.Tk):
             orphan_max_len=int(self.orphan_len_var.get()),
             remove_headers_footers=self.rm_edges_var.get(),
             page_break_mode="visible" if self.page_breaks_var.get() else "off",
-            export_images=self.export_images_var.get(),
+            export_images="white" if self.export_images_var.get() else "off",
         )
 
         # Run pipeline on a background thread; pass password as ephemeral arg

--- a/pdfmd/app_gui.py
+++ b/pdfmd/app_gui.py
@@ -1023,7 +1023,7 @@ class PdfMdApp(tk.Tk):
             heading_size_ratio=float(self.heading_ratio_var.get()),
             orphan_max_len=int(self.orphan_len_var.get()),
             remove_headers_footers=self.rm_edges_var.get(),
-            insert_page_breaks=self.page_breaks_var.get(),
+            page_break_mode="visible" if self.page_breaks_var.get() else "off",
             export_images=self.export_images_var.get(),
         )
 

--- a/pdfmd/cli.py
+++ b/pdfmd/cli.py
@@ -161,8 +161,15 @@ Security notes:
 
     parser.add_argument(
         "--export-images",
-        action="store_true",
-        help="Export images to an _assets/ folder and append Markdown references.",
+        nargs="?",
+        const="white",
+        default=None,
+        choices=["white", "black", "transparent"],
+        help=(
+            "Export images to an _assets/ folder and append Markdown references.\n"
+            "Optional value sets the background for transparent pixels:\n"
+            "  white (default) | black | transparent (keep alpha)."
+        ),
     )
 
     parser.add_argument(
@@ -245,7 +252,7 @@ def _make_options(args: argparse.Namespace) -> Options:
 
     # Rendering / output
     opts.page_break_mode = args.page_breaks or "off"
-    opts.export_images = bool(args.export_images)
+    opts.export_images = args.export_images or "off"
 
     # Transform heuristics remain at their defaults; they can be exposed later.
     return opts

--- a/pdfmd/cli.py
+++ b/pdfmd/cli.py
@@ -167,8 +167,16 @@ Security notes:
 
     parser.add_argument(
         "--page-breaks",
-        action="store_true",
-        help="Insert '---' page break markers between pages in the output.",
+        nargs="?",
+        const="visible",
+        default=None,
+        choices=["visible", "hidden"],
+        help=(
+            "Insert page markers between pages (default: visible). "
+            "'visible' inserts '---' horizontal rules. "
+            "'hidden' inserts <!-- Page N --> HTML comments "
+            "(preserves cross-page paragraph flow; ideal for LLM ingestion)."
+        ),
     )
 
     parser.add_argument(
@@ -236,7 +244,7 @@ def _make_options(args: argparse.Namespace) -> Options:
     opts.preview_only = bool(args.preview_only)
 
     # Rendering / output
-    opts.insert_page_breaks = bool(args.page_breaks)
+    opts.page_break_mode = args.page_breaks or "off"
     opts.export_images = bool(args.export_images)
 
     # Transform heuristics remain at their defaults; they can be exposed later.

--- a/pdfmd/models.py
+++ b/pdfmd/models.py
@@ -172,7 +172,7 @@ class Options:
 
     # Rendering / output
     page_break_mode: str = "off"  # "off", "visible", "hidden"
-    export_images: bool = False
+    export_images: str = "off"  # "off", "white", "black", "transparent"
 
 
 # ------------------------------ Utilities ------------------------------

--- a/pdfmd/models.py
+++ b/pdfmd/models.py
@@ -171,7 +171,7 @@ class Options:
     remove_headers_footers: bool = True
 
     # Rendering / output
-    insert_page_breaks: bool = False
+    page_break_mode: str = "off"  # "off", "visible", "hidden"
     export_images: bool = False
 
 

--- a/pdfmd/pipeline.py
+++ b/pdfmd/pipeline.py
@@ -22,13 +22,16 @@ Notes:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Optional, List, Dict
+from typing import Callable, Optional, List, Dict, Tuple
+import io
 import os
 
 try:
     import fitz  # PyMuPDF
 except Exception:
     fitz = None
+
+from PIL import Image
 
 from .models import Options
 from .extract import extract_pages, _open_pdf_with_password
@@ -68,6 +71,60 @@ def _append_image_refs(md: str, page_to_relpaths: Dict[int, List[str]]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def _normalize_pixmap(pix) -> "fitz.Pixmap":
+    """Convert a PyMuPDF Pixmap to RGB with no alpha."""
+    if pix.colorspace and pix.colorspace.n > 3:
+        pix = fitz.Pixmap(fitz.csRGB, pix)
+    if pix.alpha:
+        pix = fitz.Pixmap(pix, 0)
+    return pix
+
+
+def _pixmap_to_pil(pix) -> Image.Image:
+    """Convert a PyMuPDF Pixmap to a PIL Image."""
+    return Image.open(io.BytesIO(pix.tobytes("png")))
+
+
+def _group_tile_strips(
+    entries: List[Tuple["fitz.Pixmap", "fitz.Rect"]],
+    tol: float = 2.0,
+) -> List[List[int]]:
+    """Group images that form vertical tile strips.
+
+    Images are considered part of the same strip when they share the same
+    x-span (within *tol* points) and their y-coordinates are consecutive
+    (y0 of the next image ≈ y1 of the previous, within *tol*).
+
+    Returns list of groups, each group being a list of indices into *entries*.
+    """
+    indexed = sorted(range(len(entries)), key=lambda i: (round(entries[i][1].x0), round(entries[i][1].y0)))
+    groups: List[List[int]] = []
+    for i in indexed:
+        _, rect = entries[i]
+        if groups:
+            last_idx = groups[-1][-1]
+            _, prev_rect = entries[last_idx]
+            same_x = abs(rect.x0 - prev_rect.x0) < tol and abs(rect.x1 - prev_rect.x1) < tol
+            consecutive_y = abs(rect.y0 - prev_rect.y1) < tol
+            if same_x and consecutive_y:
+                groups[-1].append(i)
+                continue
+        groups.append([i])
+    return groups
+
+
+def _stitch_vertical(pil_images: List[Image.Image]) -> Image.Image:
+    """Stitch PIL Images vertically into a single image."""
+    total_w = max(im.width for im in pil_images)
+    total_h = sum(im.height for im in pil_images)
+    merged = Image.new("RGB", (total_w, total_h))
+    y = 0
+    for im in pil_images:
+        merged.paste(im, (0, y))
+        y += im.height
+    return merged
+
+
 def _export_images(
     pdf_path: str,
     output_md: str,
@@ -79,29 +136,18 @@ def _export_images(
 
     Returns a mapping: page_index → [relpath, ...].
 
-    For password-protected PDFs, the password is used only to open the
-    document in memory. It is never logged or persisted.
-    
-    Args:
-        pdf_path: Path to input PDF
-        output_md: Path to output Markdown file
-        options: Conversion options
-        log_cb: Optional logging callback
-        pdf_password: Optional PDF password (ephemeral, in-memory only)
-        
-    Returns:
-        Dictionary mapping page indices to lists of relative image paths
+    Adjacent tile strips (images sharing the same x-span with consecutive
+    y-coordinates) are automatically detected and stitched into a single image.
     """
     if not options.export_images:
         return {}
-    
+
     if fitz is None:
         if log_cb:
             log_cb("[pipeline] PyMuPDF is not available; cannot export images.")
         return {}
 
     try:
-        # Reuse the central password-aware open helper so behavior matches extract.py
         doc = _open_pdf_with_password(pdf_path, pdf_password)
     except Exception as e:
         if log_cb:
@@ -120,48 +166,56 @@ def _export_images(
         for pno in range(limit):
             page = doc.load_page(pno)
             images = page.get_images(full=True)
-            rels: List[str] = []
-            
-            for idx, img in enumerate(images, start=1):
+
+            # Collect pixmaps and their placement rects
+            entries: List[Tuple[fitz.Pixmap, fitz.Rect]] = []
+            for img in images:
                 xref = img[0]
                 try:
-                    pix = fitz.Pixmap(doc, xref)
+                    pix = _normalize_pixmap(fitz.Pixmap(doc, xref))
                 except Exception as exc:
                     if log_cb:
                         log_cb(f"[pipeline] Skipping image xref={xref} on page {pno + 1}: {exc}")
                     continue
-                
-                # Convert any non-RGB/Gray colorspace (CMYK, ICC, etc.) to RGB.
-                # PNG only supports RGB(A) and Gray(A), so anything else must
-                # be converted before saving.
-                if pix.colorspace and pix.colorspace.n > 3:
-                    pix = fitz.Pixmap(fitz.csRGB, pix)
-                
-                # Drop alpha channel if present — avoids issues with some
-                # viewers and keeps file sizes smaller.
-                if pix.alpha:
-                    pix = fitz.Pixmap(pix, 0)  # 0 = drop alpha
-                
-                fname = assets_dir / f"img_{pno + 1:03d}_{idx:02d}.png"
+                rects = page.get_image_rects(xref)
+                rect = rects[0] if rects else fitz.Rect(0, len(entries) * 1000, 1, len(entries) * 1000 + 1)
+                entries.append((pix, rect))
+
+            if not entries:
+                continue
+
+            groups = _group_tile_strips(entries)
+            rels: List[str] = []
+            img_idx = 0
+
+            for group in groups:
+                img_idx += 1
+                fname = assets_dir / f"img_{pno + 1:03d}_{img_idx:02d}.png"
                 try:
-                    pix.save(str(fname))
+                    if len(group) == 1:
+                        entries[group[0]][0].save(str(fname))
+                    else:
+                        pil_images = [_pixmap_to_pil(entries[i][0]) for i in group]
+                        merged = _stitch_vertical(pil_images)
+                        merged.save(str(fname))
+                        if log_cb:
+                            log_cb(f"[pipeline] Stitched {len(group)} tiles → {fname.name}")
                 except Exception as exc:
                     if log_cb:
-                        log_cb(f"[pipeline] Could not save image p{pno + 1}-{idx}: {exc}")
+                        log_cb(f"[pipeline] Could not save image p{pno + 1}-{img_idx}: {exc}")
                     continue
-                
-                # Markdown wants forward slashes for portability
+
                 rel = assets_dir.name + "/" + fname.name
                 rels.append(rel)
-            
+
             if rels:
                 mapping[pno] = rels
-        
+
         if log_cb and mapping:
             log_cb(f"[pipeline] Exported images to folder: {assets_dir}")
-        
+
         return mapping
-    
+
     finally:
         doc.close()
 

--- a/pdfmd/pipeline.py
+++ b/pdfmd/pipeline.py
@@ -71,12 +71,27 @@ def _append_image_refs(md: str, page_to_relpaths: Dict[int, List[str]]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _normalize_pixmap(pix) -> "fitz.Pixmap":
-    """Convert a PyMuPDF Pixmap to RGB with no alpha."""
+def _normalize_pixmap(pix, bg: str = "white") -> "fitz.Pixmap":
+    """Convert a PyMuPDF Pixmap to RGB, handling alpha per *bg*.
+
+    bg controls how transparent pixels are handled:
+      "white"       – composite onto white (default, best for documents)
+      "black"       – composite onto black
+      "transparent" – keep alpha channel intact
+    """
     if pix.colorspace and pix.colorspace.n > 3:
         pix = fitz.Pixmap(fitz.csRGB, pix)
     if pix.alpha:
-        pix = fitz.Pixmap(pix, 0)
+        if bg == "transparent":
+            pass  # keep alpha
+        elif bg == "black":
+            pix = fitz.Pixmap(pix, 0)
+        else:  # "white"
+            pil_img = Image.open(io.BytesIO(pix.tobytes("png"))).convert("RGBA")
+            white_bg = Image.new("RGB", pil_img.size, (255, 255, 255))
+            white_bg.paste(pil_img, mask=pil_img.split()[3])
+            samples = white_bg.tobytes()
+            pix = fitz.Pixmap(fitz.csRGB, pil_img.width, pil_img.height, samples, 0)
     return pix
 
 
@@ -177,7 +192,7 @@ def _export_images(
     Adjacent tile strips (images sharing the same x-span with consecutive
     y-coordinates) are automatically detected and stitched into a single image.
     """
-    if not options.export_images:
+    if options.export_images == "off":
         return {}
 
     if fitz is None:
@@ -210,7 +225,7 @@ def _export_images(
             for img in images:
                 xref = img[0]
                 try:
-                    pix = _normalize_pixmap(fitz.Pixmap(doc, xref))
+                    pix = _normalize_pixmap(fitz.Pixmap(doc, xref), bg=options.export_images)
                 except Exception as exc:
                     if log_cb:
                         log_cb(f"[pipeline] Skipping image xref={xref} on page {pno + 1}: {exc}")
@@ -364,7 +379,7 @@ def pdf_to_markdown(
         progress_cb(80, 100)
 
     # --- Stage 4: Optional image export ---
-    if options.export_images:
+    if options.export_images != "off":
         if log_cb:
             log_cb("[pipeline] Exporting images…")
         

--- a/pdfmd/pipeline.py
+++ b/pdfmd/pipeline.py
@@ -234,6 +234,31 @@ def _export_images(
                 rect = rects[0] if rects else fitz.Rect(0, len(entries) * 1000, 1, len(entries) * 1000 + 1)
                 entries.append((pix, rect))
 
+            # Also collect inline images embedded in the content stream.
+            # These have xref=0 and are invisible to get_images(), but
+            # appear as type-1 blocks in get_text('dict').  Common in
+            # PowerPoint-exported PDFs.
+            blocks = page.get_text("dict")["blocks"]
+            for blk in blocks:
+                if blk["type"] != 1:
+                    continue
+                try:
+                    pix = _normalize_pixmap(
+                        fitz.Pixmap(blk["image"]), bg=options.export_images
+                    )
+                except Exception:
+                    continue
+                rect = fitz.Rect(blk["bbox"])
+                # Skip if an XObject entry already covers this image
+                dup = False
+                for epix, erect in entries:
+                    if epix.width == pix.width and epix.height == pix.height:
+                        if abs(erect.x0 - rect.x0) < 5 and abs(erect.y0 - rect.y0) < 5:
+                            dup = True
+                            break
+                if not dup:
+                    entries.append((pix, rect))
+
             if not entries:
                 continue
 

--- a/pdfmd/pipeline.py
+++ b/pdfmd/pipeline.py
@@ -162,6 +162,7 @@ def _stitch_vertical(pil_images: List[Image.Image]) -> Image.Image:
     return merged
 
 
+
 def _export_images(
     pdf_path: str,
     output_md: str,

--- a/pdfmd/pipeline.py
+++ b/pdfmd/pipeline.py
@@ -113,6 +113,43 @@ def _group_tile_strips(
     return groups
 
 
+def _filter_overlapped(
+    entries: List[Tuple["fitz.Pixmap", "fitz.Rect"]],
+    overlap_threshold: float = 0.5,
+) -> List[int]:
+    """Return indices of images to keep, dropping small images that are
+    significantly overlapped by a larger image.
+
+    An image is dropped when another image's rect covers more than
+    *overlap_threshold* of its area and the other image has a larger area.
+    """
+    keep = set(range(len(entries)))
+    for i in range(len(entries)):
+        if i not in keep:
+            continue
+        ri = entries[i][1]
+        area_i = ri.get_area()
+        if area_i <= 0:
+            continue
+        for j in range(len(entries)):
+            if j == i or j not in keep:
+                continue
+            rj = entries[j][1]
+            area_j = rj.get_area()
+            # Compute intersection
+            ix0 = max(ri.x0, rj.x0)
+            iy0 = max(ri.y0, rj.y0)
+            ix1 = min(ri.x1, rj.x1)
+            iy1 = min(ri.y1, rj.y1)
+            if ix0 >= ix1 or iy0 >= iy1:
+                continue
+            inter = (ix1 - ix0) * (iy1 - iy0)
+            # Drop j if it's smaller and mostly covered by i
+            if area_j < area_i and inter / area_j > overlap_threshold:
+                keep.discard(j)
+    return sorted(keep)
+
+
 def _stitch_vertical(pil_images: List[Image.Image]) -> Image.Image:
     """Stitch PIL Images vertically into a single image."""
     total_w = max(im.width for im in pil_images)
@@ -183,6 +220,15 @@ def _export_images(
 
             if not entries:
                 continue
+
+            # Drop small images that are mostly overlapped by a larger one
+            # (e.g. decorative clip-art layered on top of an illustration)
+            keep_indices = _filter_overlapped(entries)
+            if len(keep_indices) < len(entries):
+                dropped = len(entries) - len(keep_indices)
+                entries = [entries[i] for i in keep_indices]
+                if log_cb:
+                    log_cb(f"[pipeline] Dropped {dropped} overlapped fragment(s) on page {pno + 1}")
 
             groups = _group_tile_strips(entries)
             rels: List[str] = []

--- a/pdfmd/render.py
+++ b/pdfmd/render.py
@@ -103,47 +103,6 @@ def _unwrap_hard_breaks(lines: List[str]) -> str:
     return "\n".join(out)
 
 
-def _defragment_orphans(md: str, max_len: int = 45) -> str:
-    """Merge short, isolated lines back into the previous paragraph.
-
-    This operates on the final Markdown string, post-assembly.
-
-    Heuristic:
-    - If a non-heading line is:
-        * sandwiched between blank lines
-        * short (<= max_len chars)
-        * not already a list item,
-      then we append it to the previous non-blank line.
-    """
-    lines = md.splitlines()
-    res: List[str] = []
-    i = 0
-
-    while i < len(lines):
-        line = lines[i]
-
-        if (
-            i > 0
-            and i < len(lines) - 1
-            and not lines[i - 1].strip()
-            and not lines[i + 1].strip()
-            and 0 < len(line.strip()) <= max_len
-            and not line.strip().startswith("#")
-        ):
-            # Attach orphan to the previous non-blank line
-            j = len(res) - 1
-            while j >= 0 and not res[j].strip():
-                j -= 1
-            if j >= 0:
-                res[j] = (res[j].rstrip() + " " + line.strip()).strip()
-                i += 2
-                continue
-
-        res.append(line)
-        i += 1
-
-    return "\n".join(res)
-
 
 # ---------------------------------------------------------------------------
 # Safe joining & footer detection reuse
@@ -547,26 +506,146 @@ def render_document(
                 )
             )
 
-        if options.insert_page_breaks and i < total - 1:
-            md_lines.extend(["---", ""])  # page rule
+        if i < total - 1:
+            md_lines.append(_PAGE_BREAK_MARKER)
 
         if progress_cb:
             progress_cb(i + 1, total)
 
-    md = "\n".join(md_lines)
-    # Collapse excessive blank lines
-    md = re.sub(r"\n{3,}", "\n\n", md).strip() + "\n"
+    # Post-process each page independently, then join with page breaks.
+    page_mds: List[str] = []
+    buf: List[str] = []
+    for line in md_lines:
+        if line is _PAGE_BREAK_MARKER:
+            page_mds.append("\n".join(buf))
+            buf = []
+        else:
+            buf.append(line)
+    page_mds.append("\n".join(buf))  # last page
 
-    if options.defragment_short:
-        md = _defragment_orphans(md, max_len=options.orphan_max_len)
+    cleaned = [
+        _postprocess(p, defragment=options.defragment_short,
+                     orphan_max_len=options.orphan_max_len)
+        for p in page_mds
+    ]
 
-    # Strip common footer artefacts like trailing "- - 1" or "- -" at end of lines
-    md = re.sub(r"\s*-+\s*-+\s*\d*\s*$", "", md, flags=re.MULTILINE)
+    sep = "\n---\n\n" if options.insert_page_breaks else "\n"
+    return sep.join(cleaned)
 
-    # Tighten spaces before punctuation
-    md = re.sub(r"\s+([,.;:?!])", r"\1", md)
 
-    return md
+# ---------------------------------------------------------------------------
+#   Post-processing (no regex)
+# ---------------------------------------------------------------------------
+
+_PAGE_BREAK_MARKER = object()  # identity sentinel for splitting pages
+
+
+def _postprocess(
+    md: str,
+    *,
+    defragment: bool = True,
+    orphan_max_len: int = 45,
+) -> str:
+    """Clean up rendered Markdown with simple line-by-line logic."""
+    lines = md.splitlines()
+    out: List[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        # --- Collapse blank lines: at most one consecutive blank ---
+        if not stripped:
+            if out and not out[-1].strip():
+                continue  # skip consecutive blank
+            out.append("")
+            continue
+
+        # --- Strip footer artefacts like trailing "- - 1" or "- -" ---
+        # Walk backwards from the end; if we find only dashes, spaces, and
+        # at most one trailing number, strip that suffix.
+        cleaned = _strip_dash_footer(stripped)
+        out.append(cleaned)
+
+    # --- Defragment short orphan lines ---
+    if defragment:
+        out = _defragment_orphans_list(out, max_len=orphan_max_len)
+
+    # --- Tighten spaces before punctuation ---
+    result: List[str] = []
+    for line in out:
+        for ch in ",.;:?!":
+            line = line.replace(f" {ch}", ch)
+        result.append(line)
+
+    return "\n".join(result).strip() + "\n"
+
+
+def _strip_dash_footer(line: str) -> str:
+    """Remove trailing footer artefacts like '- - 1' or '- -' from a line.
+
+    Only strips when the suffix is clearly a footer pattern (dashes separated
+    by spaces, optionally followed by a page number).  Does not touch lines
+    that are *only* dashes (e.g. '---').
+    """
+    # Find the last non-dash, non-space, non-digit character.
+    i = len(line) - 1
+    while i >= 0 and line[i] in "- \t0123456789":
+        i -= 1
+
+    if i < 0:
+        # Entire line is dashes/spaces/digits — not a footer, keep as-is.
+        return line
+
+    suffix = line[i + 1 :]
+    # A footer suffix must contain at least two dashes.
+    dash_count = suffix.count("-")
+    if dash_count >= 2:
+        return line[: i + 1].rstrip()
+
+    return line
+
+
+def _defragment_orphans_list(
+    lines: List[str], max_len: int = 45
+) -> List[str]:
+    """Merge short, isolated lines back into the previous paragraph.
+
+    A line is an orphan if it is:
+      - sandwiched between blank lines
+      - short (<= max_len chars)
+      - not a heading, list item, or page-break sentinel
+    """
+    res: List[str] = []
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        is_orphan = (
+            i > 0
+            and i < n - 1
+            and not lines[i - 1].strip()
+            and not lines[i + 1].strip()
+            and 0 < len(stripped) <= max_len
+            and not stripped.startswith("#")
+        )
+
+        if is_orphan:
+            # Find previous non-blank line in result to attach to.
+            j = len(res) - 1
+            while j >= 0 and not res[j].strip():
+                j -= 1
+            if j >= 0:
+                res[j] = res[j].rstrip() + " " + stripped
+                i += 2  # skip orphan + trailing blank
+                continue
+
+        res.append(line)
+        i += 1
+
+    return res
 
 
 __all__ = [

--- a/pdfmd/render.py
+++ b/pdfmd/render.py
@@ -512,25 +512,53 @@ def render_document(
         if progress_cb:
             progress_cb(i + 1, total)
 
-    # Post-process each page independently, then join with page breaks.
-    page_mds: List[str] = []
-    buf: List[str] = []
+    mode = options.page_break_mode
+
+    if mode == "visible":
+        # Per-page post-processing; join with visible "---" separators.
+        page_mds: List[str] = []
+        buf: List[str] = []
+        for line in md_lines:
+            if line is _PAGE_BREAK_MARKER:
+                page_mds.append("\n".join(buf))
+                buf = []
+            else:
+                buf.append(line)
+        page_mds.append("\n".join(buf))
+
+        cleaned = [
+            _postprocess(p, defragment=options.defragment_short,
+                         orphan_max_len=options.orphan_max_len)
+            for p in page_mds
+        ]
+        return "\n---\n\n".join(cleaned)
+
+    # "hidden" or "off": full-document post-processing so cross-page
+    # paragraphs can be merged by the defragmenter.
+    # Replace sentinel objects with unique per-page strings that survive
+    # cleanup, then swap them for <!-- Page N --> afterwards.
+    page_num = 2
+    flat: List[str] = []
     for line in md_lines:
         if line is _PAGE_BREAK_MARKER:
-            page_mds.append("\n".join(buf))
-            buf = []
+            if mode == "hidden":
+                flat.append(f"\x00PAGE{page_num}\x00")
+            # "off" mode: just drop the marker
+            page_num += 1
         else:
-            buf.append(line)
-    page_mds.append("\n".join(buf))  # last page
+            flat.append(line)
 
-    cleaned = [
-        _postprocess(p, defragment=options.defragment_short,
-                     orphan_max_len=options.orphan_max_len)
-        for p in page_mds
-    ]
+    md = _postprocess(
+        "\n".join(flat),
+        defragment=options.defragment_short,
+        orphan_max_len=options.orphan_max_len,
+    )
 
-    sep = "\n---\n\n" if options.insert_page_breaks else "\n"
-    return sep.join(cleaned)
+    if mode == "hidden":
+        for n in range(2, page_num):
+            md = md.replace(f"\x00PAGE{n}\x00", f"<!-- Page {n} -->")
+
+    return md
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The --- page break were inserted inline and removed by post-processing. To address this, we modified it to preserve the page break tag and introduced two modes of page break, A. "visible" B. "hidden" where visible replace the protected page break during processing to "\n---\n\n" and the invisible one insert a <!-- page N --> that aid in LLM processing of the generated markdown knowing the section every image belong to.

This PR's commits were created using Claude Code

